### PR TITLE
pylint and whitespace cleanup, and password complexity fix

### DIFF
--- a/password_checker.py
+++ b/password_checker.py
@@ -34,6 +34,7 @@ def main():
                 if ".edu" in line.lower() or '.edu.' in line.lower(): #or '.edu:' in line.lower():
                     try:
                         password = line.split(args.dl[0])[1].split('\r')[0]
+                        password = password.rstrip()
                         password = password.strip('\n')
                         #print password
                         if rate_password(password) == 'Strong' or rate_password(password) == 'Best':

--- a/password_checker.py
+++ b/password_checker.py
@@ -7,38 +7,24 @@ import re
 import argparse
 
 def rate_password(password):
+    '''rate_password - checks password complexity'''
     password_scores = {0:'Horrible', 1:'Weak', 2:'Medium', 3:'Strong', 4:'Best'}
     password_strength = dict.fromkeys(['has_upper', 'has_lower', 'has_num', 'has_symbol'], False)
-    if re.search(r'[A-Z]', password):
-        password_strength['has_upper'] = True
-        #print 'upper found'
-    else: 
-        password_strength['has_upper'] = False
-    if re.search(r'[a-z]', password):
-        password_strength['has_lower'] = True
-        #print 'lower found'
-    else: 
-        password_strength['has_lower'] = False
-    if re.search(r'[0-9]', password):
-        password_strength['has_num'] = True
-        #print 'num found'
-    else: 
-        password_strength['has_num'] = False
-    if re.search(r'[\W]', password):
-        password_strength['has_symbol'] = True
-        #print 'symbol found'
-    else: 
-        password_strength['has_symbol'] = False
+    password_strength['has_upper'] = bool(re.search(r'[A-Z]', password))
+    password_strength['has_lower'] = bool(re.search(r'[a-z]', password))
+    password_strength['has_num'] = bool(re.search(r'[0-9]', password))
+    password_strength['has_symbol'] = bool(re.search(r'[\W]', password))
     score = len([b for b in password_strength.values() if b])
     #print '{}:{}'.format(password, password_scores[score])
     return password_scores[score]
 
 def main():
-    parser = argparse.ArgumentParser()  
+    '''main - reads in file and returns results'''
+    parser = argparse.ArgumentParser()
     parser.add_argument('-v', '--version', action='version',
-        version = '%(prog)s 0.1.0') 
-    parser.add_argument('file', type=str, nargs='+', 
-        help='RIHF file(s) with passwords')
+                        version='%(prog)s 0.1.0')
+    parser.add_argument('file', type=str, nargs='+',
+                        help='RIHF file(s) with passwords')
     parser.add_argument('--dl', '--delimiter', nargs=1, default=':')
     args = parser.parse_args()
     for data in args.file:


### PR DESCRIPTION
1. I did the pylint suggestions, whitespace, and tab cleanup in one commit. No functional differences, just a little cleaner. Note the definition docstrings could possibly be a little more accurate.
2. If a textfile had lines with trailing whitespaces (e.g. "username:password "), the trailing whitespace counted as a symbol when calculating complexity. I figured statistically, if there's a trailing whitespace it's an error in the textfile and probably not a trailing whitespace in the password. See line 37 of the latest file version.